### PR TITLE
fix: np.float deprecated since numpy 1.20.0

### DIFF
--- a/vidaug/augmentors/intensity.py
+++ b/vidaug/augmentors/intensity.py
@@ -129,7 +129,7 @@ class Pepper(object):
 
         data_final = []
         for i in range(len(clip)):
-            img = clip[i].astype(np.float)
+            img = clip[i].astype(np.float64)
             img_shape = img.shape
             noise = np.random.randint(self.ratio, size=img_shape)
             img = np.where(noise == 0, 0, img)
@@ -159,7 +159,7 @@ class Salt(object):
 
         data_final = []
         for i in range(len(clip)):
-            img = clip[i].astype(np.float)
+            img = clip[i].astype(np.float64)
             img_shape = img.shape
             noise = np.random.randint(self.ratio, size=img_shape)
             img = np.where(noise == 0, 255, img)


### PR DESCRIPTION
np.float deprecated since numpy 1.20.0 and removed from numpy 1.24.0. So, np.float is replaced with np.float64 as suggested by numpy warning.